### PR TITLE
jupyterlab_widgets 3.0.13 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ requirements:
     - pip
     - python
     - jupyter-packaging >=0.10,<2
-    - setuptools
-    - wheel
   run:
     - python
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab_widgets" %}
-{% set version = "3.0.10" %}
+{% set version = "3.0.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyterlab_widgets-{{ version }}.tar.gz
-  sha256: 04f2ac04976727e4f9d0fa91cdc2f1ab860f965e504c29dbd6a65c882c9d04c0
+  sha256: a2966d385328c1942b683a8cd96b89b8dd82c8b8f81dda902bb2bc06d46f5bed
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
     - pip
     - python
     - jupyter-packaging >=0.10,<2
+    - setuptools
+    - wheel
   run:
     - python
   run_constrained:


### PR DESCRIPTION
jupyterlab_widgets 3.0.13 

**Destination channel:** Defaults

### Links

- [PKG-6422]
- dev_url:        https://github.com/jupyter-widgets/ipywidgets/tree/main
- pypi:           https://pypi.org/project/jupyterlab-widgets/3.0.13/


### Explanation of changes:

- new version number
- required for https://github.com/AnacondaRecipes/ipywidgets-feedstock/pull/14


[PKG-6422]: https://anaconda.atlassian.net/browse/PKG-6422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ